### PR TITLE
feat: Add a searchbox to filter items from window tree

### DIFF
--- a/AngryTreeGroup.lua
+++ b/AngryTreeGroup.lua
@@ -388,7 +388,8 @@ local methods = {
 						self:BuildLevel(v.children, level+1, line)
 					end
 				end
-			elseif v.visible ~= false or not self.filter then
+			elseif (v.visible ~= false or not self.filter) and
+			       (self.searchKeyword == nil or self.searchKeyword == "" or string.find(v.text, self.searchKeyword)) then
 				addLine(self, v, tree, level, parent)
 			end
 		end
@@ -618,6 +619,11 @@ local methods = {
 	["LayoutFinished"] = function(self, width, height)
 		if self.noAutoHeight then return end
 		self:SetHeight((height or 0) + 20)
+	end,
+
+	["SetSearchKeyword"] = function(self, searchKeyword)
+		self.searchKeyword = searchKeyword
+		self:RefreshTree()
 	end
 }
 

--- a/Core.lua
+++ b/Core.lua
@@ -904,6 +904,21 @@ function AngryAssign:CreateWindow()
 	window.frame:SetClampedToScreen(true)
 	tinsert(UISpecialFrames, "AngryAssign_Window")
 
+	local header = AceGUI:Create("SimpleGroup")
+	header:SetLayout("Flow")
+	header:SetFullWidth(true)
+	window:AddChild(header)
+
+	local searchLabel = AceGUI:Create("Label")
+	searchLabel:SetText("Search:")
+	searchLabel:SetWidth(40)
+	header:AddChild(searchLabel)
+
+	local searchBox = AceGUI:Create("EditBox")
+	searchBox:DisableButton(true)
+	searchBox:SetCallback("OnTextChanged", function(_, _, v) AngryAssign.window.tree:SetSearchKeyword(v) end)
+	header:AddChild(searchBox)
+
 	local tree = AceGUI:Create("AngryTreeGroup")
 	tree:SetTree( self:GetTree() )
 	tree:SelectByValue(1)


### PR DESCRIPTION
**Context**
- It's difficult to navigate when there are a lot of tree items (usually shared by multiple raid leaders)
- Adding a simple searchbox to filter by the name of tree items would mitigate this.

**Changes**
- Core.lua
  - Added a header line as SimpleGroup and added to AA window
  - Added a label and a searchbox to the header line
  - Added OnTextChanged handler which sets searchKeyword in AngryTreeGroup
- AngryTreeGroup.lua
  - SetSearchGroup - sets searchKeyword and refreshes tree
  - BuildLevel - filters line when the searchKeyword is set to a non empty value